### PR TITLE
copy frame name

### DIFF
--- a/src/graph_internal.cpp
+++ b/src/graph_internal.cpp
@@ -35,7 +35,7 @@ bool Graph::Path(const std::string& source, const std::string& target,
   queue<string> queue;
   queue.push(source);
   while (!queue.empty()) {
-    const string& current = queue.front();
+    const string current = queue.front();
 
     if (current == target) {
       string cur = target;


### PR DESCRIPTION
The [`std::queue::front()`](https://en.cppreference.com/w/cpp/container/queue/front) method provides a reference to the first element. Since the `queue` is changed afterwards, the variable `current` should store a copy of the value instead of its reference.

Fixes https://github.com/jstnhuang/robot_markers/issues/2